### PR TITLE
Fixes

### DIFF
--- a/src/js/angular-datepicker.js
+++ b/src/js/angular-datepicker.js
@@ -156,7 +156,7 @@
         angular.element($window).bind('click focus', function onClickOnWindow() {
 
           if (!isMouseOn &&
-            !isMouseOnInput) {
+            !isMouseOnInput && theCalendar) {
 
             $scope.hideCalendar();
           }
@@ -204,7 +204,7 @@
             $scope.monthNumber += 1;
           }
           //set next month
-          $scope.month = $filter('date')(new Date($scope.year + '/' + $scope.monthNumber + '/01'), 'MMMM');
+          $scope.month = $filter('date')(new Date($scope.year,  $scope.monthNumber - 1), 'MMMM');
           //reinit days
           $scope.setDaysInMonth($scope.monthNumber, $scope.year);
 
@@ -238,7 +238,7 @@
             $scope.monthNumber -= 1;
           }
           //set next month
-          $scope.month = $filter('date')(new Date($scope.year + '/' + $scope.monthNumber + '/01'), 'MMMM');
+          $scope.month = $filter('date')(new Date($scope.year, $scope.monthNumber - 1), 'MMMM');
           //reinit days
           $scope.setDaysInMonth($scope.monthNumber, $scope.year);
           //check if min date is ok


### PR DESCRIPTION
Fix to #42(Firefox issue on changing month) and #51(Uncaught TypeError:
Cannot read property 'className' of null)
NOTE: The fix for #51 might be more global - the problem when creating a new Date object with a month that has only one digit may occur in other functions as well. This matter is for further investigation.
